### PR TITLE
Feature_2025.02.02.15.11_データベースリセット時の依存性を追加

### DIFF
--- a/backend_src/backend/collected_rewards/migrations/0001_initial.py
+++ b/backend_src/backend/collected_rewards/migrations/0001_initial.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        ('movie_posters', '0001_initial'),  # 依存するアプリの初期マイグレーションを指定
     ]
 
     operations = [

--- a/backend_src/backend/treasure_rewards/management/commands/fetch_raw_tmdb_response.py
+++ b/backend_src/backend/treasure_rewards/management/commands/fetch_raw_tmdb_response.py
@@ -1,0 +1,51 @@
+import os
+import requests
+import random
+import json
+from django.core.management.base import BaseCommand
+from dotenv import load_dotenv
+
+# .envファイルを読み込む
+load_dotenv()
+
+TMDB_API_KEY = os.getenv("TMDB_API_KEY")
+TMDB_BASE_URL = "https://api.themoviedb.org/3"
+
+
+def fetch_raw_tmdb_response(endpoint):
+    """TMDB API から指定したエンドポイントのレスポンスを取得"""
+    try:
+        random_page = random.randint(1, 500)  # ランダムなページ番号を選択
+        url = f"{TMDB_BASE_URL}/{endpoint}?api_key={TMDB_API_KEY}&language=ja&page={random_page}"
+        response = requests.get(url)
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to fetch data: {response.status_code}")
+
+        return response.json()  # JSONのまま返す
+
+    except Exception as e:
+        print(f"エラー: {e}")
+        return None
+
+
+class Command(BaseCommand):
+    help = "Fetch raw TMDB response for a given endpoint"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "endpoint",
+            type=str,
+            help="TMDB API のエンドポイントを指定 (例: movie/popular, discover/movie)",
+        )
+
+    def handle(self, *args, **options):
+        endpoint = options["endpoint"]
+        self.stdout.write(f"=== TMDB の生のレスポンスを取得: {endpoint} ===")
+
+        raw_response = fetch_raw_tmdb_response(endpoint)
+
+        if raw_response:
+            print(json.dumps(raw_response, indent=4, ensure_ascii=False))  # 見やすくJSON整形
+        else:
+            self.stdout.write("データ取得に失敗しました。")


### PR DESCRIPTION
### 概要
<!-- このプルリクエストが何を解決するためのものであるか簡潔に記載してください -->
 - データベースをリセットした後の再migrationを行うときの依存性の追記

### 変更内容
<!-- このプルリクエストで具体的に何を変更したのか、またその理由を説明してください -->
[変更内容]
 - backend / django
   - migrationの依存性を追加
   - tmdbのレスポンスを確認するカスタムコマンドを作成

### 動作確認方法
<!-- 動作確認の手順や注意事項を記載してください -->
 - データベースをリセット
```
rm backend_src/backend/db.sqlite3
```
 - データベースを再migrate
```
docker compose exec backend python manage.py migrate
```

### 関連するIssueやプルリクエスト
<!-- 関連するIssueやプルリクエストがあればリンクを記載してください -->
- Related Issue: none
- Related PR: none
