### PR TITLE
Build_2025.02.03.05.18_Heroku deploy設定

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-python.git

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ backend_src/backend/treasure_rewards/management/frontend_src/*
 frontend_src/node/frontend/public/assets/movie_posters/
 backend_src/backend/db.sqlite3
 backend_src/backend/media/
+backend_src/static/frontend

--- a/backend_src/backend/backend/settings.py
+++ b/backend_src/backend/backend/settings.py
@@ -185,7 +185,13 @@ ALLOWED_HOSTS = ["*"]
 DEBUG = os.getenv("DEBUG", "False") == "True"
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-STATIC_URL = '/static/'
+import os
+# フロントエンドの静的ファイルを読み込む
+STATIC_URL = "/static/"
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, "static"),
+]
+
 
 # Heroku の環境変数を考慮
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/frontend_src/node/frontend/package.json
+++ b/frontend_src/node/frontend/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    // "build": "tsc -b && vite build",
+    "build": "vite build --outDir=../../backend_src/static/frontend",
+    "heroku-postbuild": "yarn install && yarn build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,6 +2,21 @@ build:
   docker:
     backend: backend_src/docker/python/Dockerfile
     frontend: frontend_src/docker/node/Dockerfile
+  config:
+    NODE_ENV: production
+  buildpacks:
+    - heroku/nodejs
+    - heroku/python
+  steps:
+    - run:
+        command: |
+          cd frontend_src/node/frontend && yarn install && yarn build
+          mkdir -p ../../backend_src/static/frontend
+          mv dist/* ../../backend_src/static/frontend/
+    - run:
+        command: |
+          cd backend_src && pip install -r requirements.txt
+
 
 release:
   command:
@@ -10,3 +25,4 @@ release:
 run:
   backend: python backend_src/backend/manage.py runserver 0.0.0.0:8000
   frontend: yarn --cwd frontend_src/node/frontend dev --host
+


### PR DESCRIPTION
### 概要
<!-- このプルリクエストが何を解決するためのものであるか簡潔に記載してください -->

### 変更内容
<!-- このプルリクエストで具体的に何を変更したのか、またその理由を説明してください -->

heroku-buildpack-multi を使用する
バックエンド（Django）とフロントエンド（Vite）を1つのアプリ内で動かす場合、heroku-buildpack-multi を使うと、複数のビルドパックを適切に設定できます。

```
heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi.git
```

ルートに .buildpacks ファイルを作成して、次のように設定します：

```
https://github.com/heroku/heroku-buildpack-nodejs.git
https://github.com/heroku/heroku-buildpack-python.git
```
これにより、フロントエンド（Node.js）→ バックエンド（Python）の順番でビルドされます。

2. heroku.yml を修正
Herokuに frontend_src/node/frontend/ をフロントエンドのルートとして認識させるため、 
heroku.yml を作成または修正します。

```
build:
  buildpacks:
    - heroku/nodejs
    - heroku/python
  steps:
    - run:
        command: |
          cd frontend_src/node/frontend && yarn install && yarn build
          mkdir -p ../../backend_src/static/frontend
          mv dist/* ../../backend_src/static/frontend/
    - run:
        command: |
          cd backend_src && pip install -r requirements.txt
```

 - cd frontend_src/node/frontend でフロントエンドをビルド
 - 出力された dist/ フォルダを backend_src/static/frontend/ に移動
 - backend_src/ でDjangoの依存関係をインストール

3. Procfile を設定
backend_src/Procfile に以下を記述し、HerokuがDjangoのサーバーを起動するようにします。

```
web: gunicorn backend.wsgi --log-file -
```

4. .gitignore に static/frontend を追加
フロントエンドのビルドファイルはHerokuで生成されるので、ローカルでは .gitignore に追加しておきます。

```
backend_src/static/frontend
```

5. 再デプロイ
修正後、もう一度Herokuへデプロイします。

```
git add .
git commit -m "Fix Heroku build issue"
git push heroku main
```

### 動作確認方法

<!-- 動作確認の手順や注意事項を記載してください -->

### 関連するIssueやプルリクエスト

<!-- 関連するIssueやプルリクエストがあればリンクを記載してください -->
- Related Issue: # 
- Related PR: #
