### PR TITLE
Build 2025.02.04.07.24 renderのdeploy設定 frontend

### DIFF
--- a/frontend_src/node/frontend/package.json
+++ b/frontend_src/node/frontend/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    // "build": "tsc -b && vite build",
-    "build": "vite build --outDir=../../backend_src/static/frontend",
+    "build": "tsc -b && vite build",
     "heroku-postbuild": "yarn install && yarn build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/frontend_src/node/frontend/src/utils/axiosInstance.ts
+++ b/frontend_src/node/frontend/src/utils/axiosInstance.ts
@@ -30,17 +30,3 @@ const getCsrfToken = async () => {
 getCsrfToken();
 
 export default axiosInstance;
-
-// const myBaseUrl = 'http://127.0.0.1:8000/';
-
-
-const AxiosInstance = axios.create({
-    baseURL: myBaseUrl,
-    timeout: 5000,
-    headers: {
-        "Content-Type":"application/json",
-        accept: "application/json"
-    }
-});
-
-export default AxiosInstance

--- a/frontend_src/node/frontend/src/utils/axiosInstance.ts
+++ b/frontend_src/node/frontend/src/utils/axiosInstance.ts
@@ -1,8 +1,17 @@
 import axios from "axios";
 
+const isDevelopment = import.meta.env.MODE === 'development'
+const myBaseUrl = isDevelopment ? import.meta.env.VITE_API_BASE_URL_LOCAL : import.meta.env.VITE_API_BASE_URL_DEPLOY
+
 const axiosInstance = axios.create({
-  baseURL: "http://localhost:8000/api", // DjangoのAPIのベースURL
+  // baseURL: "http://localhost:8000/api", // DjangoのAPIのベースURL
+  baseURL: myBaseUrl, // DjangoのAPIのベースURL
+  timeout: 5000,
   withCredentials: true, // CSRFトークンを送信するためにクッキーを有効化
+  headers: {
+    "Content-Type":"application/json",
+    accept: "application/json"
+  }
 });
 
 // CSRFトークンを取得し、Axiosインスタンスのデフォルトヘッダーに設定
@@ -21,3 +30,17 @@ const getCsrfToken = async () => {
 getCsrfToken();
 
 export default axiosInstance;
+
+// const myBaseUrl = 'http://127.0.0.1:8000/';
+
+
+const AxiosInstance = axios.create({
+    baseURL: myBaseUrl,
+    timeout: 5000,
+    headers: {
+        "Content-Type":"application/json",
+        accept: "application/json"
+    }
+});
+
+export default AxiosInstance


### PR DESCRIPTION
### 概要
<!-- このプルリクエストが何を解決するためのものであるか簡潔に記載してください -->
 - renderのデプロイエラーに対する修正
![image](https://github.com/user-attachments/assets/df0620b1-3403-45e4-a9db-e925e1b31ed8)

### 変更内容
<!-- このプルリクエストで具体的に何を変更したのか、またその理由を説明してください -->
[変更内容]
 - renderのデプロイエラーに対する修正（frontend）

[エラー内容]
```
parse error: Invalid numeric literal at line 8, column 7 ==> Using Node.js version 22.12.0 (default)
==> Docs on specifying a Node.js version: https://render.com/docs/node-version ==> Using Bun version 1.1.0 (default)
==> Docs on specifying a bun version: https://render.com/docs/bun-version yarn install v1.22.22
error SyntaxError: /opt/render/project/src/frontend_src/node/frontend/package.json: Expected double-quoted property name in JSON at position
```

### 動作確認方法
<!-- 動作確認の手順や注意事項を記載してください -->
render内でデプロイ再トライ

### 関連するIssueやプルリクエスト

<!-- 関連するIssueやプルリクエストがあればリンクを記載してください -->
- Related Issue: # 
- Related PR: #


