### PR TITLE
Build_2025.02.05.19.09_renderへのデプロイ設定

### DIFF
--- a/backend_src/backend/backend/deployment_settings.py
+++ b/backend_src/backend/backend/deployment_settings.py
@@ -22,7 +22,7 @@ MIDDLEWARE = [
 ]
 
 CORS_ALLOWED_ORIGINS = [
-    'https://render-deploy-tutorial-reactjs-code.onrender.com'
+    'https://moviedig-frontend.onrender.com/'
 ]
 
 STORAGES = {


### PR DESCRIPTION
### 概要
<!-- このプルリクエストが何を解決するためのものであるか簡潔に記載してください -->
 - renderにデプロイしたページでバックエンドのapiが動作しないため、デプロイ設定ファイルでCORS設定をする

### 変更内容
 - deployment_settings.pyのCORS_ALLOWED_ORIGINSをrenderのfrontend(静的ページ)に設定
 - 
### 動作確認方法
<!-- 動作確認の手順や注意事項を記載してください -->
 - renderで静的ページにアクセス
 - バックエンドのapiが動作するかを確認

### 関連するIssueやプルリクエスト
<!-- 関連するIssueやプルリクエストがあればリンクを記載してください -->
- Related Issue: none 
- Related PR: none

