### PR TITLE
Build_2025.02.05.19.20_renderのデプロイ設定

### DIFF
--- a/backend_src/backend/backend/deployment_settings.py
+++ b/backend_src/backend/backend/deployment_settings.py
@@ -21,8 +21,13 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+ALLOWED_HOSTS = [
+    os.environ.get('RENDER_EXTERNAL_HOSTNAME', 'moviedig.onrender.com')
+]
+
+
 CORS_ALLOWED_ORIGINS = [
-    'https://moviedig-frontend.onrender.com/'
+    'https://moviedig-frontend.onrender.com'
 ]
 
 STORAGES = {


### PR DESCRIPTION
### 概要
<!-- このプルリクエストが何を解決するためのものであるか簡潔に記載してください -->
 - renderのデプロイエラーに対する修正

### 変更内容
<!-- このプルリクエストで具体的に何を変更したのか、またその理由を説明してください -->
 - renderのデプロイエラーに対する修正
   - Invalid HTTP_HOST header: 'moviedig.onrender.com'. You may need to add 'moviedig.onrender.com' to ALLOWED_HOSTS.
 - 修正内容
   - deployment_settings.pyのALLOWED_HOSTSにmoviedig.onrender.comを追加

### 動作確認方法
<!-- 動作確認の手順や注意事項を記載してください -->
再デプロイを試行し、エラーが起こらないか確認する

### 関連するIssueやプルリクエスト

<!-- 関連するIssueやプルリクエストがあればリンクを記載してください -->
- Related Issue: none
- Related PR: none



