### PR TITLE
Debug 2025.02.10.06.59 本番環境で/api/rewards/collectが404エラー

### DIFF
--- a/backend_src/backend/collected_rewards/views.py
+++ b/backend_src/backend/collected_rewards/views.py
@@ -16,7 +16,7 @@ from .serializers import MoviePosterSerializer
 # loggerを設定
 logger = logging.getLogger(__name__)
 
-@method_decorator(csrf_exempt, name='dispatch')
+# @method_decorator(csrf_exempt, name='dispatch')
 class CollectRewardView(View):
     def post(self, request):
         logger.info("CollectRewardView received a request")  # 確認用ログ


### PR DESCRIPTION
### 概要
<!-- このプルリクエストが何を解決するためのものであるか簡潔に記載してください -->
 - render production環境
   - api/reward/collect 発火時の404tエラーが起こることに対する修正

### 変更内容
<!-- このプルリクエストで具体的に何を変更したのか、またその理由を説明してください -->
 - api/reward/collect発火時の csrf_exempt をコメントアウト

### 動作確認方法
<!-- 動作確認の手順や注意事項を記載してください -->
 - renderへdeploy
 - api/reward/collect 発火時の404tエラーが起こらないことを確認 

### 関連するIssueやプルリクエスト
<!-- 関連するIssueやプルリクエストがあればリンクを記載してください -->
- Related Issue: 
  - none 
- Related PR: 
  - none 
